### PR TITLE
Update ring.py

### DIFF
--- a/ring.py
+++ b/ring.py
@@ -77,7 +77,7 @@ def getDeviceInfo(dev):
     dev.update()
     logger.info("Updating device data for device '"+dev.name+"' in FHEM...")
     srRing('account ' + str(dev.account_id), dev)
-    srRing('address ' + str(dev.address), dev) 
+    srRing('address ' + dev.address, dev) 
     srRing('family ' + str(dev.family), dev) 
     srRing('id ' + str(dev.id), dev) 
     srRing('name ' + str(dev.name), dev) 


### PR DESCRIPTION
str(dev.address) sorgt bei Adressen mit Sonderzeichen/Umlauten (non-ascii Zeichen) für Fehler. dev.address ist schon Unicode, durch str() wird versucht dies in ascii zu wandeln was bei Umlauten eben zur Exception führt.